### PR TITLE
fix!: Update backend URL and fix batch

### DIFF
--- a/examples/csv_batch.ts
+++ b/examples/csv_batch.ts
@@ -40,7 +40,7 @@ fs.createReadStream('./input_emails.csv')
 	// then into a CheckEmailInput object (with a `to_email` field), and push
 	// this object into the queue.
 	.on('data', (data: string[]) => {
-		q.push(data.map((email) => ({ to_email: email }))).catch(console.error);
+		q.push(data.map((email) => ({ to_email: email })));
 	})
 	// When we finish processing the whole CSV file, we call `.drain` on the
 	// queue, and pass a callback function where we output the results as CSV.

--- a/examples/csv_batch.ts
+++ b/examples/csv_batch.ts
@@ -40,7 +40,7 @@ fs.createReadStream('./input_emails.csv')
 	// then into a CheckEmailInput object (with a `to_email` field), and push
 	// this object into the queue.
 	.on('data', (data: string[]) => {
-		q.push(data.map((email) => ({ to_email: email })));
+		q.push(data.map((email) => ({ to_email: email }))); // eslint-disable-line
 	})
 	// When we finish processing the whole CSV file, we call `.drain` on the
 	// queue, and pass a callback function where we output the results as CSV.

--- a/package.json
+++ b/package.json
@@ -20,24 +20,24 @@
 		"lint": "tsc --noEmit && eslint . --ext .ts"
 	},
 	"dependencies": {
-		"@types/async": "^3.2.3",
-		"@types/debug": "^4.1.5",
-		"async": "^3.2.0",
-		"axios": "^0.21.0",
-		"debug": "^4.2.0"
+		"@types/async": "^3.2.8",
+		"@types/debug": "^4.1.7",
+		"async": "^3.2.1",
+		"axios": "^0.21.4",
+		"debug": "^4.3.2"
 	},
 	"devDependencies": {
 		"@amaurym/config": "^1.3.5",
-		"@manifoldco/swagger-to-ts": "^2.0.0",
-		"@types/json2csv": "^5.0.1",
-		"@types/node": "^16.0.0",
-		"csv-parse": "^4.10.1",
-		"json2csv": "^5.0.3",
-		"standard-version": "^9.0.0",
-		"ts-node": "^10.0.0",
-		"typedoc": "^0.22.3",
-		"typedoc-plugin-markdown": "^3.0.2",
-		"typedoc-plugin-no-inherit": "^1.1.10",
-		"typescript": "^4.0.2"
+		"@manifoldco/swagger-to-ts": "^2.1.0",
+		"@types/json2csv": "^5.0.3",
+		"@types/node": "^16.9.4",
+		"csv-parse": "^4.16.3",
+		"json2csv": "^5.0.6",
+		"standard-version": "^9.3.1",
+		"ts-node": "^10.2.1",
+		"typedoc": "^0.22.4",
+		"typedoc-plugin-markdown": "^3.11.0",
+		"typedoc-plugin-no-inherit": "^1.3.0",
+		"typescript": "^4.4.3"
 	}
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,4 +1,4 @@
-import { QueueObject, queue } from 'async';
+import { queue, QueueObject } from 'async';
 import { debug } from 'debug';
 
 import {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,4 +1,4 @@
-import { AsyncQueue, queue } from 'async';
+import { QueueObject, queue } from 'async';
 import { debug } from 'debug';
 
 import {
@@ -43,7 +43,7 @@ const DEFAULT_CONCURRENCY = 100;
  */
 export function batchQueue(
 	options: CheckBatchOptions = {}
-): AsyncQueue<CheckEmailInput> {
+): QueueObject<CheckEmailInput> {
 	l('Creating a batch queue.');
 
 	const q = queue<CheckEmailInput>((task, callback) => {

--- a/src/single.ts
+++ b/src/single.ts
@@ -56,11 +56,9 @@ export function checkSingle(
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const headers: Record<string, string> = {
 		'Content-Type': 'application/json',
+		Authorization: options.apiToken || 'test_api_token',
 		...options.axios?.headers,
 	};
-	if (options.apiToken) {
-		headers.Authorization = options.apiToken;
-	}
 
 	return axios
 		.post<CheckEmailOutput>(backendUrl, input, {

--- a/src/single.ts
+++ b/src/single.ts
@@ -14,10 +14,9 @@ export interface CheckEmailInput extends ICheckEmailInput {}
 export interface CheckEmailOutput extends ICheckEmailOutput {}
 
 /**
- * Reacher's backend base URL, without the version number
+ * Reacher's backend URL.
  */
-const REACHER_BACKEND_URL = `https://ssfy.sh/amaurym/reacher`;
-const REACHER_LASTEST_VERSION = '0.1.6';
+const REACHER_BACKEND_URL = 'https://api.reacher.email/v0/check_email';
 
 /**
  * Options for checking an email.
@@ -29,17 +28,12 @@ export interface CheckSingleOptions {
 	 */
 	apiToken?: string;
 	/**
-	 * Backend version of Reacher to use. The latest version is 0.1.5.
-	 */
-	apiVersion?: '0.1.5' | '0.1.6';
-	/**
 	 * @reacherhq/api uses axios under the hood, pass axios config here.
 	 */
 	axios?: AxiosRequestConfig;
 	/**
 	 * For users self-hosting Reacher and who would not like to use the Reacher
-	 * SaaS, this option allows to override the backend URL to call. This
-	 * option overrides the `apiVersion` option.
+	 * SaaS, this option allows to override the backend URL to call.
 	 */
 	backendUrl?: string;
 }
@@ -57,11 +51,7 @@ export function checkSingle(
 ): Promise<CheckEmailOutput> {
 	l('Processing email %s', input.to_email);
 
-	const backendUrl =
-		options.backendUrl ||
-		`${REACHER_BACKEND_URL}@${
-			options.apiVersion || REACHER_LASTEST_VERSION
-		}/check_email`;
+	const backendUrl = options.backendUrl || REACHER_BACKEND_URL;
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const headers: Record<string, string> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,7 @@ export interface components {
 			username: string;
 		};
 		/**
-		 * An enum to describe how confident we are that the recipient address is real: `safe`, `risky`, `invalid` and `unknown`. Check our FAQ to know the meanings of the 4 possibilities: https://www.notion.so/reacherhq/Reacher-FAQ-389d6f51a53749f29d914239613c64eb.
+		 * An enum to describe how confident we are that the recipient address is real: `safe`, `risky`, `invalid` and `unknown`. Check our FAQ to know the meanings of the 4 possibilities: https://help.reacher.email/email-attributes-inside-json.
 		 */
 		Reachable: 'invalid' | 'unknown' | 'safe' | 'risky';
 		/**
@@ -135,6 +135,17 @@ export interface components {
 			 * In the SMTP connection, the EHLO hostname.
 			 */
 			hello_name?: string;
+			proxy?: components['schemas']['CheckEmailInputProxy'];
+		};
+		CheckEmailInputProxy: {
+			/**
+			 * The proxy host.
+			 */
+			host: string;
+			/**
+			 * The proxy port.
+			 */
+			port: number;
 		};
 	};
 }


### PR DESCRIPTION
BREAKING:
The `apiVersion` option has been removed, please pass an optional `backendUrl` option if you do not want to use Reacher's  backend (https://github.com/reacherhq/backend, hosted on `https://api.reacher.email`).